### PR TITLE
Add version to manifest.json

### DIFF
--- a/custom_components/read_your_meter/manifest.json
+++ b/custom_components/read_your_meter/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "",
   "dependencies": [],
   "codeowners": ["@eyalcha"],
-  "requirements": ["selenium", "beautifulsoup4"]
+  "requirements": ["selenium", "beautifulsoup4"],
+  "version": "1.0.11"
 }


### PR DESCRIPTION
Fixes integration being blocked from loading

`The custom integration 'read_your_meter' does not have a valid version key (None) in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details`