### PR TITLE
specify selenium version

### DIFF
--- a/custom_components/read_your_meter/manifest.json
+++ b/custom_components/read_your_meter/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "",
   "dependencies": [],
   "codeowners": ["@eyalcha"],
-  "requirements": ["selenium", "beautifulsoup4"]
+  "requirements": ["selenium==4.2.0", "beautifulsoup4"]
 }


### PR DESCRIPTION
downgrade selenium python package from the latest to 4.2.0
find_element_by_X is no longer supported by 4.3.0
